### PR TITLE
Handle Rollbar ignored exceptions through an initializer.

### DIFF
--- a/lib/cru_lib.rb
+++ b/lib/cru_lib.rb
@@ -3,6 +3,7 @@ require 'cru_lib/async'
 require 'cru_lib/global_registry_methods'
 require 'cru_lib/global_registry_relationship_methods'
 require 'cru_lib/global_registry_master_person_methods'
+require 'cru_lib/railtie'
 
 module CruLib
 end

--- a/lib/cru_lib/global_registry_master_person_methods.rb
+++ b/lib/cru_lib/global_registry_master_person_methods.rb
@@ -34,11 +34,7 @@ module CruLib
     end
   end
 
-  class NoGlobalRegistryIdError < Rollbar::Ignore; end
+  class NoGlobalRegistryIdError < StandardError; end
 
-  class NoGlobalRegistryMasterPersonError < Rollbar::Ignore; end
-end
-
-module Rollbar
-  class Ignore < StandardError; end
+  class NoGlobalRegistryMasterPersonError < StandardError; end
 end

--- a/lib/cru_lib/railtie.rb
+++ b/lib/cru_lib/railtie.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module CruLib
+  class Railtie < Rails::Railtie
+    initializer 'crulib_railtie.configure_rollbar' do
+      if Module::const_defined? :Rollbar
+        ::Rollbar.configure do |config|
+          config.exception_level_filters.merge!('CruLib::NoGlobalRegistryIdError' => 'ignore',
+                                                'CruLib::NoGlobalRegistryMasterPersonError' => 'ignore')
+        end
+      end
+    end
+  end
+end

--- a/lib/cru_lib/version.rb
+++ b/lib/cru_lib/version.rb
@@ -1,3 +1,3 @@
 module CruLib
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
Remove the `Rollbar::Ignore` exception subclassing. Daniel Goers found this only worked in very specific situations.
Instead, I implemented this as a Railtie initializer which will add our CruLib exceptions to the Rollbar ignored list if the including project has Rollbar.